### PR TITLE
Fix anchor links and interpolated string

### DIFF
--- a/docs/documentation_dev/07_i18n.md
+++ b/docs/documentation_dev/07_i18n.md
@@ -18,7 +18,7 @@ The library [dom-i18n](https://github.com/ruyadorno/dom-i18n) provides an very e
 
 1. Usage within HTML: `<h2 data-i18n="">About AsTeRICS Grid // Über das AsTeRICS Grid</h2>`
    * property `data-i18n` on an HTML element indicates that the content of this `h2` tag is internationalized
-   * content in different languages is placed directly within the HTML element, separated by `//`
+   * content in different languages is placed directly within the HTML element, separated by " // "
    * first language is English, second German
 1. For displaying only the content of the correct language, in the Javascript part of the component this code has to be executed (see [aboutView.vue:88](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/vue-components/views/aboutView.vue#L88)):
 

--- a/docs/documentation_dev/07_i18n.md
+++ b/docs/documentation_dev/07_i18n.md
@@ -7,8 +7,8 @@ next: false
 This chapter is about internationalization (translation of elements) in AsTeRICS Grid which can be done in three ways:
 
 1. [dom-i18n](07_i18n.md#dom-i18n)
-1. [i18nService.js](07_i18n.md#i18nservicejs)
-1. [Vue.js filter](07_i18n.md#vuejs-filter)
+1. [i18nService.js](07_i18n.md#i18nservice-js)
+1. [Vue.js filter](07_i18n.md#vue-js-filter)
 
 [Back to Overview](README.md)
 
@@ -62,7 +62,7 @@ The result will be a confirmation dialog containing:
 
 ## Vue.js filter
 
-There is also an implemented Vue.js filter for translation which uses the `i18nService.translate()` method. It's implemented in [vuePluginManager.js#initFilters()](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/js/vue/vuePluginManager.js#L39). General usage is a pipe within any double curly braces expression, for instance `{{ variableToTranslate | translate }}`. A real use-case could look like this:
+There is also an implemented Vue.js filter for translation which uses the `i18nService.translate()` method. It's implemented in [vuePluginManager.js#initFilters()](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/js/vue/vuePluginManager.js#L39). General usage is a pipe within any double curly braces expression, for instance `{{"\{\{ variableToTranslate \| translate \}\}"}}`. A real use-case could look like this:
 
 ```
 <li v-for="action in gridElement.actions">

--- a/docs/documentation_dev/07_i18n.md
+++ b/docs/documentation_dev/07_i18n.md
@@ -1,10 +1,14 @@
+---
+next: false
+---
+
 # Internationalization
 
 This chapter is about internationalization (translation of elements) in AsTeRICS Grid which can be done in three ways:
 
 1. [dom-i18n](07_i18n.md#dom-i18n)
-1. [i18nService.js](07_i18n.md#i18nservice-js)
-1. [Vue.js filter](07_i18n.md#vue-js-filter)
+1. [i18nService.js](07_i18n.md#i18nservicejs)
+1. [Vue.js filter](07_i18n.md#vuejs-filter)
 
 [Back to Overview](README.md)
 
@@ -13,9 +17,9 @@ This chapter is about internationalization (translation of elements) in AsTeRICS
 The library [dom-i18n](https://github.com/ruyadorno/dom-i18n) provides an very easy to use possibility for adding translations to an HTML site. Wherever possible it's used within AsTeRICS Grid. The file [aboutView.vue](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/vue-components/views/aboutView.vue) shows it's usage within a Vue component:
 
 1. Usage within HTML: `<h2 data-i18n="">About AsTeRICS Grid // Über das AsTeRICS Grid</h2>`
-   - property `data-i18n` on an HTML element indicates that the content of this `h2` tag is internationalized
-   - content in different languages is placed directly within the HTML element, separated by `//`
-   - first language is English, second German
+   * property `data-i18n` on an HTML element indicates that the content of this `h2` tag is internationalized
+   * content in different languages is placed directly within the HTML element, separated by `//`
+   * first language is English, second German
 1. For displaying only the content of the correct language, in the Javascript part of the component this code has to be executed (see [aboutView.vue:88](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/vue-components/views/aboutView.vue#L88)):
 
    ```
@@ -24,9 +28,9 @@ The library [dom-i18n](https://github.com/ruyadorno/dom-i18n) provides an very e
    }
    ```
 
-   - the `mounted()` function is called by Vue.js after initialization of the component
-   - `i18nService.initDomI18n()` initializes the dom-i18n library for this component, showing only the translations of correct language
-   - if it's a dynamic Vue.js component it's maybe necessary to call `i18nService.initDomI18n()` also in the Vue.js `updated()` method which is called after each view update
+   * the `mounted()` function is called by Vue.js after initialization of the component
+   * `i18nService.initDomI18n()` initializes the dom-i18n library for this component, showing only the translations of correct language
+   * if it's a dynamic Vue.js component it's maybe necessary to call `i18nService.initDomI18n()` also in the Vue.js `updated()` method which is called after each view update
 
 The dom-i18n library is initialized in [i18nService.js](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/js/service/i18nService.js). There it would be possible to add additional languages by adding it to the `language` property within the `i18nService.initDomI18n()` method.
 
@@ -53,12 +57,12 @@ i18nService.translations['de']['CONFIRM_DELETE_GRID'] = 'Möchten Sie das Grid "
 
 The result will be a confirmation dialog containing:
 
-- non-german browser setting: _Do you really want to delete the grid "My grid"?_
-- german browser setting: _Möchten Sie das Grid "My grid" wirklich löschen?_
+* non-german browser setting: *Do you really want to delete the grid "My grid"?*
+* german browser setting: *Möchten Sie das Grid "My grid" wirklich löschen?*
 
 ## Vue.js filter
 
-There is also an implemented Vue.js filter for translation which uses the `i18nService.translate()` method. It's implemented in [vuePluginManager.js#initFilters()](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/js/vue/vuePluginManager.js#L39). General usage is a pipe within any double curly braces expression, for instance `\{\{variableToTranslate | translate\}\}`. A real use-case could look like this:
+There is also an implemented Vue.js filter for translation which uses the `i18nService.translate()` method. It's implemented in [vuePluginManager.js#initFilters()](https://github.com/asterics/AsTeRICS-Grid/blob/master/src/js/vue/vuePluginManager.js#L39). General usage is a pipe within any double curly braces expression, for instance `{{ variableToTranslate | translate }}`. A real use-case could look like this:
 
 ```
 <li v-for="action in gridElement.actions">


### PR DESCRIPTION
Hi,

I've reverted the previous changes, which were unnecessary. As soon as you integrate this PR, I'll build a new version of `asterics-docs` and deploy it to https://www.asterics.eu/next/.

* The anchor are not correct for `asterics-docs` but for the GitHub rendered markdown. We'll have to decide which one should be correct in future. Both are not possible, as far as I can tell.
* Changes from \* to \_ etc. have been reverted
* `\{\{variableToTranslate | translate\}\}` changed to `{{ variableToTranslate | translate }}`. Everthing within `{{ }} ` is executed/interpolated by Vue during the build. For a correct rendering in 'asterics-docs`, this needs to be changed to `{{ "\{\{variableToTranslate \| translate \}\}" }}`.
* The previous ` // ` is still changed to `//` because it is not rendered as you've intended. Please consider fixing it if necessary.

I didn't know, that you want to render with or use the GitHub Markdown features. Both styles (GitHub, vuepress) cannot be supported (or only with some effort) at the same time. Some of the content also looks odd on the `asterics-docs` page, like the TOC (which is provided by default by vuepress) and navigation links (previous, next).

How do you want to use this documentation in future?