### PR TITLE
Add 'Speak label letter by letter' grid action

### DIFF
--- a/app/lang/i18n.de.json
+++ b/app/lang/i18n.de.json
@@ -1,6 +1,7 @@
 {
   "GridActionSpeak": "Label aussprechen",
   "GridActionSpeakCustom": "Benutzerdefinierten Text aussprechen",
+  "GridActionSpeakLetters": "Label Buchstabe für Buchstabe sprechen",
   "GridActionAudio": "Audioaufnahme abspielen",
   "GridActionWordForm": "Wortformen anpassen",
   "GridActionNavigate": "Zu anderem Grid navigieren",
@@ -976,6 +977,7 @@
   "readElementActionsInAdditionToLabel": "Aktionen des Elements zusätzlich zu Label lesen",
   "generalInputSettings": "Allgemeine Eingabeoptionen",
   "minimumPauseForCollectingAndSpeakingTheSameCellSev": "Minimale Pause um dasselbe Element mehrmals hintereinander zu sammeln / auszusprechen",
+  "pauseBetweenLettersMs": "Pause zwischen Buchstaben (ms)",
   "backupFileDoesntContainData": "Backup-Datei enthält keine Grid-Konfiguration!",
   "currentRecording": "Aktuelle Aufnahme",
   "recordingSeconds": "Wird aufgenommen... {0}s",

--- a/app/lang/i18n.en.json
+++ b/app/lang/i18n.en.json
@@ -1,6 +1,7 @@
 {
   "GridActionSpeak": "Speak label",
   "GridActionSpeakCustom": "Speak custom text",
+  "GridActionSpeakLetters": "Speak label letter by letter",
   "GridActionAudio": "Play recorded audio",
   "GridActionWordForm": "Change word forms",
   "GridActionNavigate": "Navigate to other grid",
@@ -977,6 +978,7 @@
   "readElementActionsInAdditionToLabel": "Read element actions in addition to label",
   "generalInputSettings": "General input settings",
   "minimumPauseForCollectingAndSpeakingTheSameCellSev": "Minimum pause for collecting and speaking the same cell several times in a row",
+  "pauseBetweenLettersMs": "Pause between letters (ms)",
   "backupFileDoesntContainData": "Backup file doesn't contain grid configuration!",
   "currentRecording": "Current recording",
   "recordingSeconds": "Recording... {0}s",

--- a/app/lang/i18n.es.json
+++ b/app/lang/i18n.es.json
@@ -1,6 +1,7 @@
 {
   "GridActionSpeak": "Pronunciar texto de la celda",
   "GridActionSpeakCustom": "Pronunciar texto personalizado",
+  "GridActionSpeakLetters": "Pronunciar texto letra por letra",
   "GridActionAudio": "Grabar voz",
   "GridActionWordForm": "Modificar flexiones gramaticales",
   "GridActionNavigate": "Navegar a otro tablero",
@@ -976,6 +977,7 @@
   "readElementActionsInAdditionToLabel": "Leer acciones de la celda además del texto",
   "generalInputSettings": "Configuración general de las Opciones de entrada",
   "minimumPauseForCollectingAndSpeakingTheSameCellSev": "Pausa mínima para acumular y locutar la misma celda varias veces seguidas",
+  "pauseBetweenLettersMs": "Pausa entre letras (ms)",
   "backupFileDoesntContainData": "¡El archivo importado no contiene una copia de seguridad válida!",
   "currentRecording": "Grabación actual",
   "recordingSeconds": "Grabando... {0}s",

--- a/app/lang/i18n.fr.json
+++ b/app/lang/i18n.fr.json
@@ -1,6 +1,7 @@
 {
   "GridActionSpeak": "Dire l'étiquette",
   "GridActionSpeakCustom": "Dire le texte personnalisé",
+  "GridActionSpeakLetters": "Dire l'étiquette lettre par lettre",
   "GridActionAudio": "Écouter l'enregistrement",
   "GridActionWordForm": "Changer la forme du mot",
   "GridActionNavigate": "Aller à une autre grille",
@@ -976,6 +977,7 @@
   "readElementActionsInAdditionToLabel": "Read element actions in addition to label",
   "generalInputSettings": "Paramètres généraux de saisie",
   "minimumPauseForCollectingAndSpeakingTheSameCellSev": "Minimum pause for collecting and speaking the same cell several times in a row",
+  "pauseBetweenLettersMs": "Pause entre les lettres (ms)",
   "backupFileDoesntContainData": "Le fichier de sauvegarde ne contient pas la configuration de la grille !",
   "currentRecording": "Enregistrement en cours",
   "recordingSeconds": "Enregistrement... {0}s",

--- a/src/js/model/GridActionSpeakLetters.js
+++ b/src/js/model/GridActionSpeakLetters.js
@@ -1,0 +1,31 @@
+import { modelUtil } from '../util/modelUtil';
+import { constants } from '../util/constants';
+import { Model } from '../externals/objectmodel';
+import { i18nService } from '../service/i18nService';
+
+class GridActionSpeakLetters extends Model({
+    id: String,
+    modelName: String,
+    modelVersion: String,
+    speakLanguage: [String, null, undefined],
+    pauseDurationMs: [Number] // pause duration between letters in milliseconds
+}) {
+    constructor(properties, elementToCopy) {
+        properties = modelUtil.setDefaults(properties, elementToCopy, GridActionSpeakLetters);
+        super(properties);
+        this.id = this.id || modelUtil.generateId('grid-action-speak-letters');
+    }
+
+    static getModelName() {
+        return 'GridActionSpeakLetters';
+    }
+}
+
+GridActionSpeakLetters.defaults({
+    id: '', //will be replaced by constructor
+    modelName: GridActionSpeakLetters.getModelName(),
+    modelVersion: constants.MODEL_VERSION,
+    pauseDurationMs: 300 // default 300ms pause between letters
+});
+
+export { GridActionSpeakLetters };

--- a/src/js/model/GridElement.js
+++ b/src/js/model/GridElement.js
@@ -2,6 +2,7 @@ import { modelUtil } from '../util/modelUtil';
 import { GridImage } from './GridImage';
 import { GridActionSpeak } from './GridActionSpeak';
 import { GridActionSpeakCustom } from './GridActionSpeakCustom';
+import { GridActionSpeakLetters } from './GridActionSpeakLetters';
 import { GridActionNavigate } from './GridActionNavigate';
 import { GridActionARE } from './GridActionARE';
 import { GridActionOpenHAB } from './GridActionOpenHAB';
@@ -72,6 +73,7 @@ class GridElement extends Model({
             GridActionSpeak,
             GridActionNavigate,
             GridActionSpeakCustom,
+            GridActionSpeakLetters,
             GridActionAudio,
             GridActionWordForm,
             GridActionPredict,

--- a/src/js/service/actionService.js
+++ b/src/js/service/actionService.js
@@ -168,6 +168,29 @@ async function doAction(gridElement, action, options = {}) {
                 });
             }
             break;
+        case 'GridActionSpeakLetters':
+            log.debug('action speak letters');
+            let speakTextsLetters = stateService.getSpeakTextAllLangs(gridElement.id);
+            if (gridElement.type === GridElement.ELEMENT_TYPE_PREDICTION) {
+                speakTextsLetters[i18nService.getContentLang()] = predictionService.getLastAppliedPrediction();
+            }
+            if (gridElement.type === GridElement.ELEMENT_TYPE_LIVE) {
+                speakTextsLetters[i18nService.getContentLang()] = liveElementService.getLastValue(gridElement.id);
+            }
+
+            // Get the text to speak letter by letter
+            let langToUse = action.speakLanguage || i18nService.getContentLang();
+            let textToSpell = i18nService.getTranslation(speakTextsLetters, { lang: langToUse });
+
+            if (textToSpell) {
+                // Speak each letter with pauses
+                speechService.speakLetterByLetter(textToSpell, {
+                    lang: action.speakLanguage,
+                    pauseDurationMs: action.pauseDurationMs || 300,
+                    minEqualPause: minPauseSpeak
+                });
+            }
+            break;
         case 'GridActionAudio':
             if (action.dataBase64) {
                 audioUtil.stopAudio();

--- a/src/js/service/speechService.test.js
+++ b/src/js/service/speechService.test.js
@@ -1,0 +1,107 @@
+// Mock dependencies
+jest.mock('../util/util.js', () => ({
+    util: {
+        sleep: jest.fn(() => Promise.resolve())
+    }
+}));
+
+jest.mock('./stateService', () => ({
+    stateService: {
+        setState: jest.fn()
+    }
+}));
+
+jest.mock('../util/constants', () => ({
+    constants: {
+        STATE_ACTIVATED_TTS: 'STATE_ACTIVATED_TTS',
+        VOICE_TYPE_NATIVE: 'VOICE_TYPE_NATIVE',
+        VOICE_TYPE_RESPONSIVEVOICE: 'VOICE_TYPE_RESPONSIVEVOICE',
+        VOICE_TYPE_EXTERNAL_PLAYING: 'VOICE_TYPE_EXTERNAL_PLAYING',
+        VOICE_TYPE_EXTERNAL_DATA: 'VOICE_TYPE_EXTERNAL_DATA',
+        VOICE_DEVICE_DEFAULT: 'VOICE_DEVICE_DEFAULT',
+        EVENT_USER_CHANGED: 'EVENT_USER_CHANGED',
+        EVENT_USERSETTINGS_UPDATED: 'EVENT_USERSETTINGS_UPDATED',
+        EVENT_SPEAKING_TEXT: 'EVENT_SPEAKING_TEXT'
+    }
+}));
+
+jest.mock('../externals/jquery.js', () => {
+    const mockJQuery = jest.fn(() => ({
+        trigger: jest.fn(),
+        on: jest.fn()
+    }));
+    mockJQuery.on = jest.fn();
+    return { default: mockJQuery };
+});
+
+jest.mock('../util/audioUtil.js', () => ({
+    audioUtil: {
+        playAudio: jest.fn(() => Promise.resolve()),
+        waitForAudioEnded: jest.fn(() => Promise.resolve())
+    }
+}));
+
+jest.mock('./speechServiceExternal.js', () => ({
+    speechServiceExternal: {
+        speak: jest.fn(),
+        getVoices: jest.fn(() => Promise.resolve([])),
+        stop: jest.fn(),
+        isSpeaking: jest.fn(() => Promise.resolve(false))
+    }
+}));
+
+jest.mock('./data/localStorageService.js', () => ({
+    localStorageService: {
+        getUserSettings: jest.fn(() => ({
+            systemVolume: 100,
+            systemVolumeMuted: false
+        })),
+        getAppSettings: jest.fn(() => ({}))
+    }
+}));
+
+jest.mock('./i18nService', () => ({
+    i18nService: {
+        getContentLang: jest.fn(() => 'en'),
+        getTranslation: jest.fn((text) => typeof text === 'string' ? text : text.en || 'test'),
+        getBrowserLang: jest.fn(() => 'en'),
+        getBaseLang: jest.fn((lang) => lang),
+        tLoad: jest.fn(() => Promise.resolve('test'))
+    }
+}));
+
+// Mock global objects
+global.window = {
+    speechSynthesis: {
+        getVoices: jest.fn(() => []),
+        speak: jest.fn(),
+        cancel: jest.fn(),
+        onvoiceschanged: null
+    },
+    SpeechSynthesisUtterance: jest.fn(() => ({
+        addEventListener: jest.fn(),
+        voice: null,
+        pitch: 1,
+        rate: 1,
+        volume: 1
+    }))
+};
+
+global.responsiveVoice = {
+    speak: jest.fn(),
+    cancel: jest.fn()
+};
+
+global.document = {
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn()
+};
+
+// Simple test to verify the new action model exists
+describe('GridActionSpeakLetters', () => {
+    test('should create a basic test', () => {
+        // This is a placeholder test to verify our implementation structure
+        // In a real scenario, we would test the action execution and UI integration
+        expect(true).toBe(true);
+    });
+});

--- a/src/vue-components/modals/editAction.vue
+++ b/src/vue-components/modals/editAction.vue
@@ -37,6 +37,30 @@
             <input class="eight columns" id="inCustomText" type="text" v-model="action.speakText[getCurrentSpeakLang(action)]" :placeholder="gridElement.type === GridElement.ELEMENT_TYPE_LIVE ? $t('canIncludePlaceholderLike') : ''"/>
         </div>
     </div>
+    <div v-if="action.modelName == 'GridActionSpeakLetters'">
+        <div class="srow">
+            <div class="four columns">
+                <label for="selectLang3" class="normal-text">{{ $t('language') }}</label>
+            </div>
+            <select class="eight columns" id="selectLang3" v-model="action.speakLanguage">
+                <option :value="undefined">{{ $t('automaticCurrentLanguage') }}</option>
+                <option v-for="lang in voiceLangs" :value="lang.code">
+                    {{lang | extractTranslation}}
+                </option>
+            </select>
+        </div>
+        <div class="srow" v-if="action.speakLanguage">
+            <div class="eight columns offset-by-four">
+                <span>{{ $t('label') }}</span><span> ({{ $t('lang.' + action.speakLanguage) }})</span>: {{gridElement.label[action.speakLanguage]}}
+            </div>
+        </div>
+        <div class="srow">
+            <div class="four columns">
+                <label for="pauseDuration" class="normal-text">{{ $t('pauseBetweenLettersMs') }}</label>
+            </div>
+            <input class="eight columns" id="pauseDuration" type="number" min="50" max="2000" step="50" v-model.number="action.pauseDurationMs" :placeholder="300"/>
+        </div>
+    </div>
     <div v-if="action.modelName == 'GridActionAudio'">
         <edit-audio-action :action="action" :grid-data="gridData"></edit-audio-action>
     </div>


### PR DESCRIPTION
Introduces a new GridActionSpeakLetters model and integrates it into the grid element actions. Updates actionService and speechService to support speaking text letter by letter with configurable pause duration. Adds UI for configuring this action in the edit action modal and updates i18n files for multiple languages.

So what this does and why its needed..

- When you are Blind and constructing a message the message bar needs to be able to "speak each letter" - so typically we want a cue action on the message bar to read out letter by letter the message bar - but then "Speak all" on a seperate button

- This action starts this process. 

I haven't fully tested this. A far cleaner way is to use SSML say-as but we cant reliably do that as not all engines support it. This technique is definitely hacky