### PR TITLE
feat: persist Application Language setting across sessions

### DIFF
--- a/src/js/model/SettingsApp.js
+++ b/src/js/model/SettingsApp.js
@@ -11,7 +11,11 @@ class SettingsApp {
     constructor(settings) {
         settings = settings || {};
         this.modelVersion = settings.modelVersion;
-        this.appLang = settings.appLang || "";
+        // Handle appLang with three states:
+        // - null/undefined: never set, use browser language
+        // - "": explicitly set to automatic, use browser language
+        // - "xx": specific language code
+        this.appLang = settings.appLang !== undefined ? settings.appLang : null;
         this.unlockPasscode = settings.unlockPasscode;
         this.syncNavigation = settings.syncNavigation;
         this.externalSpeechServiceUrl = settings.externalSpeechServiceUrl;

--- a/src/js/service/i18nService.js
+++ b/src/js/service/i18nService.js
@@ -85,11 +85,16 @@ i18nService.getContentLangReadable = function () {
 };
 
 i18nService.getAppLang = function () {
-    return i18nService.getCustomAppLang() || i18nService.getBrowserLang();
+    let customLang = i18nService.getCustomAppLang();
+    // If customLang is null (never set), use browser language
+    // If customLang is "" (explicitly set to automatic), use browser language
+    // If customLang is a language code, use that language
+    return customLang || i18nService.getBrowserLang();
 };
 
 i18nService.getCustomAppLang = function () {
-    return currentAppLang || '';
+    // Return null if never set, "" if explicitly automatic, or language code if set
+    return currentAppLang;
 };
 
 i18nService.isCurrentAppLangDE = function () {
@@ -116,12 +121,15 @@ i18nService.setAppLanguage = async function (lang, dontSave) {
     if (!dontSave) {
         localStorageService.saveAppSettings({appLang: lang});
     }
-    currentAppLang = lang || i18nService.getBrowserLang();
-    $('html').prop('lang', currentAppLang);
+    // Store the exact value passed (null, "", or language code)
+    currentAppLang = lang;
+    // But use the resolved language for actual UI language
+    let resolvedLang = i18nService.getAppLang();
+    $('html').prop('lang', resolvedLang);
     await getPredefinedActionTranslations();
-    return loadLanguage(currentAppLang).then(() => {
-        vueI18n.locale = currentAppLang;
-        allLanguages.sort((a, b) => a[currentAppLang].toLowerCase().localeCompare(b[currentAppLang].toLowerCase()));
+    return loadLanguage(resolvedLang).then(() => {
+        vueI18n.locale = resolvedLang;
+        allLanguages.sort((a, b) => a[resolvedLang].toLowerCase().localeCompare(b[resolvedLang].toLowerCase()));
         return Promise.resolve();
     });
 };

--- a/src/vue-components/views/settings/settingsGeneral.vue
+++ b/src/vue-components/views/settings/settingsGeneral.vue
@@ -5,7 +5,7 @@
                 <h3 class="mt-2">{{ $t('applicationLanguage') }}</h3>
                 <div class="srow">
                     <label class="three columns" for="inLanguage">{{ $t('selectLanguage') }}</label>
-                    <select class="five columns" id="inLanguage" v-model="appSettings.appLang" @change="saveAppSettings(appSettings)">
+                    <select class="five columns" id="inLanguage" v-model="displayAppLang" @change="onLanguageChange">
                         <option value="">{{ $t('automatic') }}</option>
                         <option v-for="lang in allLanguages.filter(langObject => appLanguages.includes(langObject.code))" :value="lang.code">{{lang | extractTranslationAppLang}} ({{lang.code}})</option>
                     </select>
@@ -67,7 +67,26 @@
                 allLanguages: i18nService.getAllLanguages()
             }
         },
+        computed: {
+            displayAppLang: {
+                get() {
+                    // Convert null (never set) to "" for display purposes
+                    return this.appSettings.appLang === null ? "" : this.appSettings.appLang;
+                },
+                set(value) {
+                    // This setter is not used since we handle changes in onLanguageChange
+                    this.appSettings.appLang = value;
+                }
+            }
+        },
         methods: {
+            onLanguageChange(event) {
+                let selectedValue = event.target.value;
+                // When user selects "Automatic" (empty string), save it as empty string (explicit choice)
+                // When user selects a specific language, save the language code
+                this.appSettings.appLang = selectedValue;
+                this.saveAppSettings(this.appSettings);
+            }
         },
         async mounted() {
         }


### PR DESCRIPTION
Re: #601

- Distinguish between null (never set) and "" (explicit automatic) in SettingsApp
- Update i18nService to properly handle three language states
- Modify settings UI to preserve user's explicit language choice
- Fix issue where specific language selection reverted to automatic on reload

Fixes language persistence for users who explicitly select a language (e.g., Hungarian users on English corporate laptops) ensuring their choice is remembered across sessions.