### PR TITLE
fix for #603

### DIFF
--- a/src/js/util/fileUtil.js
+++ b/src/js/util/fileUtil.js
@@ -25,7 +25,7 @@ fileUtil.readZip = async function(file, options = {}) {
         let file = zip.files[filename];
         let type = options.defaultEncoding || 'base64';
         let parseJson = options.jsonFileExtensions.some(ext => filename.endsWith(`.${ext}`));
-        type = parseJson ? 'binarystring' : type;
+        type = parseJson ? 'string' : type;
         promises.push(Promise.resolve().then(async () => {
             let content = await file.async(type);
             readCount++;


### PR DESCRIPTION
Polish characters like ć are stored as UTF-8 bytes in the OBZ file When reading with 'binarystring', these UTF-8 bytes weren't properly decoded This caused ć to be corrupted and displayed as Ä
Using 'string' encoding properly handles UTF-8 decoding