### PR TITLE
Fix Set Navigation modal so options appear for unsaved element

### DIFF
--- a/src/vue-components/components/gridSelector.vue
+++ b/src/vue-components/components/gridSelector.vue
@@ -73,7 +73,17 @@
                 this.grids.sort((a, b) => {
                     return i18nService.getTranslation(a.label).localeCompare(i18nService.getTranslation(b.label));
                 })
-                this.selectGrid(additionalOpts[0] || this.grids[0]);
+                let initialSelection = this.value;
+                if (initialSelection && typeof initialSelection === 'object') {
+                    let matchingGrid = this.grids.find(grid => grid.id === initialSelection.id);
+                    initialSelection = matchingGrid || initialSelection;
+                }
+                if (!initialSelection) {
+                    initialSelection = additionalOpts[0] || this.grids[0];
+                }
+                if (initialSelection) {
+                    this.selectGrid(initialSelection);
+                }
             })
         },
     }

--- a/src/vue-components/views/gridEditView.vue
+++ b/src/vue-components/views/gridEditView.vue
@@ -36,7 +36,7 @@
             <grid-translate-modal v-if="showTranslateModal" :grid-data-id="gridData.id" @close="showTranslateModal = false" @reload="reload"/>
         </div>
         <div>
-            <set-navigation-modal v-if="showNavigateModal" :grid-id="gridData.id" :grid-element-id="editElementId" @close="showNavigateModal = false" @reload="reload"></set-navigation-modal>
+            <set-navigation-modal v-if="showNavigateModal" :grid-id="gridData.id" :grid-data-param="gridData" :grid-element-id="editElementId" @close="showNavigateModal = false" @reload="reload"></set-navigation-modal>
         </div>
         <div>
             <transfer-props-modal v-if="showPropTransferModal" :grid-id="gridData.id" :grid-element-id="editElementId" @start="(propTransferObject) => startPropTransfer(propTransferObject)" @close="showPropTransferModal = false"></transfer-props-modal>


### PR DESCRIPTION
Pass current grid data into setNavigationModal so it renders options without reloading persisted state Guard save logic and prefill the selected navigation target from the existing action Let gridSelector honor an incoming v-model value before falling back to defaults

I've got no idea if this fixes #619 - I can't recreate the bug but heck - it may help