### PR TITLE
DameVoz + AsTeRICS Grid: optional sync integration (Pull Request)

### DIFF
--- a/src/js/service/data/dataService.js
+++ b/src/js/service/data/dataService.js
@@ -119,7 +119,21 @@ dataService.saveGrid = function (gridData) {
     gridData = JSON.parse(JSON.stringify(gridData));
     gridData.gridElements = gridUtil.sortGridElements(gridData.gridElements);
     gridData.lastUpdateTime = new Date().getTime();
-    return databaseService.saveObject(GridData, gridData);
+    return databaseService.saveObject(GridData, gridData).then(function (result) {
+        try {
+            let settings = localStorageService.getUserSettings();
+            if (settings.damevozEnabled === true && settings.damevozUser) {
+                fetch('https://damevoz.es/api/sync/' + encodeURIComponent(settings.damevozUser), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(gridData)
+                }).catch(function () {});
+            }
+        } catch (e) {
+            // silently ignore any error
+        }
+        return result;
+    });
 };
 
 /**

--- a/src/vue-components/views/settings/settingsIntegrations.vue
+++ b/src/vue-components/views/settings/settingsIntegrations.vue
@@ -46,6 +46,23 @@
             <button @click="currentModal = MODALS.MODAL_MATRIX"><i class="fas fa-cog"></i> {{ $t('configureMatrixMessenger') }}</button>
         </div>
         <configure-matrix v-if="currentModal === MODALS.MODAL_MATRIX" @close="currentModal = null"></configure-matrix>
+        <h3>DameVoz</h3>
+        <div class="srow">
+            <div class="eleven columns">
+                <div>
+                    <input id="damevozEnabled" type="checkbox" v-model="damevozEnabled" @change="saveDamevoz"/>
+                    <label for="damevozEnabled">Sincronizar tableros con DameVoz</label>
+                </div>
+                <div class="mt-3" v-if="damevozEnabled">
+                    <label class="three columns" for="damevozUser">Usuario de DameVoz</label>
+                    <input type="text" id="damevozUser" class="seven columns" v-model="damevozUser" @input="saveDamevoz" placeholder="tu-usuario"/>
+                </div>
+                <div class="mt-3">
+                    <span class="fa fa-info-circle"></span>
+                    <span>Los cambios en tus tableros se enviarán automáticamente a DameVoz</span>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -55,6 +72,7 @@
     import { arasaacService } from '../../../js/service/pictograms/arasaacService';
     import { speechServiceExternal } from '../../../js/service/speechServiceExternal';
     import { speechService } from '../../../js/service/speechService';
+    import { localStorageService } from '../../../js/service/data/localStorageService';
     import { settingsSaveMixin } from './settingsSaveMixin';
     import ConfigureMatrix from '../../modals/matrix-messenger/configure-matrix.vue';
 
@@ -72,7 +90,9 @@
                 arasaacService: arasaacService,
                 urlValid: null,
                 MODALS: MODALS,
-                currentModal: null
+                currentModal: null,
+                damevozEnabled: false,
+                damevozUser: ''
             }
         },
         methods: {
@@ -87,9 +107,18 @@
                         await speechService.reinit();
                     }, timeout, 'REINIT_SPEECH');
                 }
+            },
+            saveDamevoz() {
+                localStorageService.saveUserSettings({
+                    damevozEnabled: this.damevozEnabled,
+                    damevozUser: this.damevozUser
+                });
             }
         },
         async mounted() {
+            let userSettings = localStorageService.getUserSettings();
+            this.damevozEnabled = !!userSettings.damevozEnabled;
+            this.damevozUser = userSettings.damevozUser || '';
         }
     }
 </script>


### PR DESCRIPTION
Hi Benjamin,

My name is Pau, and I'm the developer behind DameVoz ("Give Me a Voice"), an independent AAC viewer built for children with communication needs in Spanish-speaking communities.

First of all, thank you for everything you and the AsTeRICS Grid team have built. AsTeRICS Grid is the backbone of what we do — DameVoz works directly with exported .grd files, and without your work, ours wouldn't exist.

DameVoz uses ARASAAC pictographic symbols, and we deeply respect the collaboration you pioneered with them. We hope to build a similar bridge between our tools.

Our project is non-commercial and exists for one reason: no child should be left without a voice. We've specifically optimized DameVoz to run on low-resource tablets commonly found in schools and homes that cannot afford high-end hardware.

I've opened a Pull Request on the AsTeRICS Grid repository with a small, optional integration:
https://github.com/asterics/AsTeRICS-Grid/pulls

The PR adds a "DameVoz" section in the Complementos/Integrations settings tab — a checkbox and a username field. When enabled, any grid saved in AsTeRICS Grid is silently synced to the child's DameVoz device in real time. This removes the need for families and therapists to manually export and re-upload .grd files every time a board is updated.

Key principles of the implementation:
- 100% opt-in, disabled by default
- Non-blocking (fire-and-forget fetch)
- No new dependencies
- Only 2 files modified
- Follows the exact same UI pattern as the existing external voice service integration

We would be honored if you considered merging it. We're happy to adjust anything based on your feedback.

Thank you for your time and for the incredible work you do for the AAC community.

Warm regards,
Pau
DameVoz Team
https://www.damevoz.es