### PR TITLE
#799 Set consistent default values for Export Grid Options

### DIFF
--- a/src/vue-components/modals/exportModal.vue
+++ b/src/vue-components/modals/exportModal.vue
@@ -118,9 +118,9 @@
                 allChildren: null,
                 options: {
                     exportConnected: true,
-                    exportDictionaries: true,
-                    exportUserSettings: true,
-                    exportGlobalGrid: true,
+                    exportDictionaries: false,
+                    exportUserSettings: false,
+                    exportGlobalGrid: false,
                     exportOBZ: false,
                     exportLang: constants.LANG_EXPORT_ALL,
                     exportLangOptions: [constants.LANG_EXPORT_ALL, constants.LANG_EXPORT_CURRENT]

--- a/src/vue-components/views/manageGridsView.vue
+++ b/src/vue-components/views/manageGridsView.vue
@@ -264,12 +264,7 @@
             exportCustom(gridId) {
                 if (gridId) {
                     this.backupModal.exportOptions.gridId = gridId;
-                    this.backupModal.exportOptions.exportDictionaries = false;
-                    this.backupModal.exportOptions.exportUserSettings = false;
-                    this.backupModal.exportOptions.exportGlobalGrid = false;
-                } else {
-                    this.backupModal.exportOptions = {}
-                }
+                } 
                 this.backupModal.show = true;
             },
             exportToPdf(gridId) {


### PR DESCRIPTION
#### Issue:
#799 

#### Changes

* Remove **disabled** override for `user settings`, `global grid`, `dictionaries` for single grid. 
* Set consistent defaults for global an single grid. 

