### PR TITLE
#716 Add additional headers and request mode header for HTTP action

### DIFF
--- a/app/lang/i18n.en.json
+++ b/app/lang/i18n.en.json
@@ -1239,6 +1239,7 @@
   "PODCAST_CURRENT_EPISODE": "Current episode title",
   "PODCAST_PLAY_TIME": "Playback time",
   "PODCAST_REMAINING_TIME": "Remaining time",
+  "noCorsMode": "Use no-cors mode",
   "useCorsProxy": "Use CORS proxy",
   "canIncludePlaceholderLike": "can include placeholder {0}, e.g. \"Data: {0}\"",
   "valuesToChooseFrom": "Values to choose from",

--- a/app/lang/i18n.en.json
+++ b/app/lang/i18n.en.json
@@ -1128,6 +1128,7 @@
   "restActionFailed": "HTTP action failed! Reason: {0}",
   "httpAuthUser": "HTTP Authentication User",
   "httpAuthPw": "HTTP Authentication Password",
+  "httpAddHeader": "HTTP Additional Headers",
   "externalSpeechUrl": "External speech service URL",
   "externalSpeechService": "External speech service",
   "infoAboutExternalSpeechService": "information about external speech service",

--- a/src/js/model/GridActionHTTP.js
+++ b/src/js/model/GridActionHTTP.js
@@ -15,7 +15,8 @@ class GridActionHTTP extends Model({
     authPw: [String], //password for http authentication,
     noCorsMode: [Boolean], // if true "no-cors" mode is used for fetch, preventing errors if CORS headers not available, but endpoint functionality still works
     useCorsProxy: [Boolean], // if true, cors proxy "proxy.asterics-foundation.org" is used,
-    isLiveAction: [Boolean]
+    isLiveAction: [Boolean],
+    additionalHeaders: [String]
 }) {
     constructor(properties, elementToCopy) {
         properties = modelUtil.setDefaults(properties, elementToCopy, GridActionHTTP);

--- a/src/js/service/httpService.js
+++ b/src/js/service/httpService.js
@@ -41,7 +41,9 @@ async function doActionInternal(action) {
             let authStringBase64 = util.stringToBase64(`${action.authUser}:${action.authPw}`);
             requestOptions.headers["Authorization"] = `Basic ${authStringBase64}`;
         }
-        requestOptions.mode = action.noCorsMode ? 'no-cors' : undefined;
+        if (action.noCorsMode) {
+            requestOptions.mode = "no-cors";
+        }
         if (action.additionalHeaders) {
             const additionalHeaders = JSON.parse(action.additionalHeaders);
             const existingHeaderKeys = Object.keys(requestOptions.headers).map((k) => k.toLowerCase());

--- a/src/js/service/httpService.js
+++ b/src/js/service/httpService.js
@@ -46,11 +46,8 @@ async function doActionInternal(action) {
         }
         if (action.additionalHeaders) {
             const additionalHeaders = JSON.parse(action.additionalHeaders);
-            const existingHeaderKeys = Object.keys(requestOptions.headers).map((k) => k.toLowerCase());
             for (let h in additionalHeaders) {
-                if (!existingHeaderKeys.includes(h.toLowerCase())) {
                     requestOptions.headers[h] = additionalHeaders[h];
-                }
             }
         }
         

--- a/src/js/service/httpService.js
+++ b/src/js/service/httpService.js
@@ -37,12 +37,21 @@ async function doActionInternal(action) {
         if (!['GET', 'HEAD'].includes(requestOptions.method)) {
             requestOptions.body = action.body;
         }
-
         if (action.authUser || action.authPw) {
             let authStringBase64 = util.stringToBase64(`${action.authUser}:${action.authPw}`);
             requestOptions.headers["Authorization"] = `Basic ${authStringBase64}`;
         }
         requestOptions.mode = action.noCorsMode ? 'no-cors' : undefined;
+        if (action.additionalHeaders) {
+            const additionalHeaders = JSON.parse(action.additionalHeaders);
+            const existingHeaderKeys = Object.keys(requestOptions.headers).map((k) => k.toLowerCase());
+            for (let h in additionalHeaders) {
+                if (!existingHeaderKeys.includes(h.toLowerCase())) {
+                    requestOptions.headers[h] = additionalHeaders[h];
+                }
+            }
+        }
+        
         let url = new URL(action.restUrl);
         if (action.useCorsProxy) {
             url = new URL('https://proxy.asterics-foundation.org/proxy_nofilter.php');

--- a/src/vue-components/modals/editActionsSub/editHttpAction.vue
+++ b/src/vue-components/modals/editActionsSub/editHttpAction.vue
@@ -35,7 +35,7 @@
                        placeholder="text/plain | application/json | ..." spellcheck="false" autocomplete="true" type="text"/>
             </div>
         </div>
-        <div class="row" v-if="action.isLiveAction">
+        <div class="row hide-row" v-if="action.isLiveAction">
             <label class="col-12 col-md-4 normal-text" for="acceptHeader">HTTP Accept Header</label>
             <div class="col-12 col-md-7">
                 <input id="acceptHeader" v-model="action.acceptHeader" class="col-12"

--- a/src/vue-components/modals/editActionsSub/editHttpAction.vue
+++ b/src/vue-components/modals/editActionsSub/editHttpAction.vue
@@ -28,7 +28,7 @@
                 </select>
             </div>
         </div>
-        <div class="row">
+        <div class="row hide-row">
             <label class="col-12 col-md-4 normal-text" for="content-type">HTTP Content-Type</label>
             <div class="col-12 col-md-7">
                 <input id="content-type" v-model="action.contentType" class="col-12"
@@ -89,5 +89,9 @@ export default {
 
 .row {
     margin-bottom: 1em;
+}
+
+.hide-row {
+    display: none;
 }
 </style>

--- a/src/vue-components/modals/editActionsSub/editHttpAction.vue
+++ b/src/vue-components/modals/editActionsSub/editHttpAction.vue
@@ -60,6 +60,12 @@
                 <textarea id="httpAddHeader" v-model="action.additionalHeaders" class="col-12" placeholder='e.g. {"Accept": "application/json", "Content-Type": "text/plain"}'></textarea>
             </div>
         </div>
+        <div class="row">
+            <div class="col-12">
+                <input id="noCorsMode" v-model="action.noCorsMode" type="checkbox"/>
+                <label class="normal-text" for="noCorsMode">{{ $t('noCorsMode') }}</label>
+            </div>
+        </div>
         <div class="row" v-if="action.isLiveAction">
             <div class="col-12">
                 <input id="useCorsProxy" v-model="action.useCorsProxy" type="checkbox"/>

--- a/src/vue-components/modals/editActionsSub/editHttpAction.vue
+++ b/src/vue-components/modals/editActionsSub/editHttpAction.vue
@@ -54,6 +54,12 @@
                 <input id="auth-pw" v-model="action.authPw" class="col-12" type="password" :placeholder="$t('optionalBracket')"/>
             </div>
         </div>
+        <div class="row">
+            <label class="col-12 col-md-4 normal-text" for="httpAddHeader">{{ $t('httpAddHeader') }}</label>
+            <div class="col-12 col-md-7">
+                <textarea id="httpAddHeader" v-model="action.additionalHeaders" class="col-12" placeholder="(optional JSON object)"></textarea>
+            </div>
+        </div>
         <div class="row" v-if="action.isLiveAction">
             <div class="col-12">
                 <input id="useCorsProxy" v-model="action.useCorsProxy" type="checkbox"/>

--- a/src/vue-components/modals/editActionsSub/editHttpAction.vue
+++ b/src/vue-components/modals/editActionsSub/editHttpAction.vue
@@ -57,7 +57,7 @@
         <div class="row">
             <label class="col-12 col-md-4 normal-text" for="httpAddHeader">{{ $t('httpAddHeader') }}</label>
             <div class="col-12 col-md-7">
-                <textarea id="httpAddHeader" v-model="action.additionalHeaders" class="col-12" placeholder="(optional JSON object)"></textarea>
+                <textarea id="httpAddHeader" v-model="action.additionalHeaders" class="col-12" placeholder='e.g. {"Accept": "application/json", "Content-Type": "text/plain"}'></textarea>
             </div>
         </div>
         <div class="row" v-if="action.isLiveAction">


### PR DESCRIPTION
### Issue: 

#716 

### Changes: 

* Add `addtionalHeaders` string( JSON) field for HTTP action.
* Add `noCorsMode` checkbox field for HTTP action.
* Hide `HTTP Content Type` header field.
* Hide `HTTP Accept Header`  field.
* Additional headers override all existing headers. This inclues current `HTTP Content Type`, `HTTP Accept Header` and, Authorization header in case of `HTTP Authentication User` and `HTTP Authentication Password`.

### Description:

Add `additionalHeaders` field for HTTP action which takes a JSON string. Primary reason is to add support for additional authentication types. This change also adds UI for `no-cors` request type. Hide the existing `Content-Type` and `Accept`( in case of live action) headers, while preserving the current values.

### TODO: 

* Add a migration to `GridActionHTTP.js` model in future, to merge hidden headers into the new `additionalHeaders` field.