### PR TITLE
#828 added initial Docker image and compose support for dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+.git
+.gitignore
+app/build
+npm-debug.log

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM node:lts-alpine
 
+LABEL version="0.1"
+LABEL description="Developer environnement for Asterics-AAC"
+
 ENV HOST=0.0.0.0
 ENV NODE_ENV=development
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,14 @@
+FROM node:lts-alpine
+
+ENV HOST=0.0.0.0
+ENV NODE_ENV=development
+
+WORKDIR /app
+
+COPY ./container/dev/entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 3000
+EXPOSE 9095
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,6 +8,9 @@ WORKDIR /app
 COPY ./container/dev/entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:9095 || exit 1
+
 EXPOSE 3000
 EXPOSE 9095
 

--- a/README.md
+++ b/README.md
@@ -71,17 +71,20 @@ After `yarn install` the following commands are available:
 
 ## Run project locally with Docker for developers
 
-1. go to the directory of the cloned project
-1. `docker compose -f ./compose.dev.yml build` --> build the container image.
-2. `docker compose -f ./compose.dev.yml up` --> start the application.
-3. `docker compose -f ./compose.dev.yml down` --> stop the application.
+1. clone the project `git clone git@github.com:asterics/Asterics-AAC.git`
+2. go to the directory of the cloned project
+3. build the container image `docker compose -f ./compose.dev.yml build`
+4. start the application `docker compose -f ./compose.dev.yml up`
+5. stop the application `docker compose -f ./compose.dev.yml down`
+
+Asterics AAC will be accessible  at `http://localhost:9095` with CouchDB configured.
 
 You can access the container shell, for example to run Npm scripts, using the following commands :
 
 - `docker exec -it asterics-aac-development-application-1 /bin/sh` --> Asterics AAC container.
 - `docker exec -it asterics-aac-development-database-1 /bin/sh` --> CouchDB container.
 
-You can also run the commands directly from the host machine :
+You can also run commands directly from the host machine :
 
 - `docker exec -it asterics-aac-development-application-1 npm run build`
 - `docker exec -it asterics-aac-development-application-1 npm run release`

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ After `yarn install` the following commands are available:
 
 You can access the container shell, for example to run Npm scripts, using the following commands :
 
-- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 /bin/sh` --> Asterics AAC container.
-- `docker exec -it asterics-aacfordevelopmentenvironment-database-1 /bin/sh` --> CouchDB container.
+- `docker exec -it asterics-aac-development-application-1 /bin/sh` --> Asterics AAC container.
+- `docker exec -it asterics-aac-development-database-1 /bin/sh` --> CouchDB container.
 
 You can also run the commands directly from the host machine :
 
-- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run build`
-- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run release`
-- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run release-latest`
-- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run test`
+- `docker exec -it asterics-aac-development-application-1 npm run build`
+- `docker exec -it asterics-aac-development-application-1 npm run release`
+- `docker exec -it asterics-aac-development-application-1 npm run release-latest`
+- `docker exec -it asterics-aac-development-application-1 npm run test`
 
 ## Support us
 While development is currently funded within research projects (see below), the non-profit [AsTeRICS Foundation](https://www.asterics-foundation.org/) pays for the running server costs. If you want to contribute to these costs, you're very welcome to donate:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ After `yarn install` the following commands are available:
 5. `npm run release-latest` -> same as `npm run release` but with destination https://grid.asterics.eu/latest/
 5. `npm run test` -> runs tests of the project using [Jest](https://jestjs.io/).
 
+## Run project locally with Docker for developers
+
+1. go to the directory of the cloned project
+1. `docker compose -f ./compose.dev.yml build` --> build the container image.
+2. `docker compose -f ./compose.dev.yml up` --> start the application.
+3. `docker compose -f ./compose.dev.yml down` --> stop the application.
+
+You can access the container shell, for example to run Npm scripts, using the following commands :
+
+- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 /bin/sh` --> Asterics AAC container.
+- `docker exec -it asterics-aacfordevelopmentenvironment-database-1 /bin/sh` --> CouchDB container.
+
+You can also run the commands directly from the host machine :
+
+- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run build`
+- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run release`
+- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run release-latest`
+- `docker exec -it asterics-aacfordevelopmentenvironment-application-1 npm run test`
+
 ## Support us
 While development is currently funded within research projects (see below), the non-profit [AsTeRICS Foundation](https://www.asterics-foundation.org/) pays for the running server costs. If you want to contribute to these costs, you're very welcome to donate:
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -29,11 +29,6 @@ services:
       - '3000:3000/tcp'
       - '9095:9095/tcp'
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   database:
     image: couchdb:3

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -22,7 +22,9 @@ services:
       - DB_SERVER_PASSWORD=${DB_SERVER_PASSWORD:-admin}
       - CAUTH_USER_DB=${CAUTH_USER_DB:-auth-users}
       - CAUTH_COUCH_AUTH_DB=${CAUTH_COUCH_AUTH_DB:-_users}
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     ports:
       - '3000:3000/tcp'
       - '9095:9095/tcp'
@@ -41,7 +43,9 @@ services:
     environment:
       - COUCHDB_USER=${DB_SERVER_USER:-admin}
       - COUCHDB_PASSWORD=${DB_SERVER_PASSWORD:-admin}
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     ports:
       - '5984:5984/tcp'
     restart: unless-stopped
@@ -59,7 +63,9 @@ services:
     environment:
       - COUCHDB_USER=${DB_SERVER_USER:-admin}
       - COUCHDB_PASSWORD=${DB_SERVER_PASSWORD:-admin}
-    env_file: .env
+    env_file:
+      - path: .env
+        required: false
     command:
       - |
         curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" -X PUT http://database:5984/_users

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,0 +1,77 @@
+name: Asterics-AAC for development environment
+
+services:
+  application:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    depends_on:
+      database:
+        condition: service_healthy
+      database-init:
+        condition: service_completed_successfully
+    volumes:
+      - .:/app
+    environment:
+      - NODE_ENV=development
+      - COUCHDB_URL=${DB_SERVER_PROTOCOL:-http://}${DB_SERVER_USER:-admin}:${DB_SERVER_PASSWORD:-admin}@database:5984
+      - DB_SERVER_PUBLIC_URL=${DB_SERVER_PROTOCOL:-http://}localhost:5984
+      - DB_SERVER_PROTOCOL=${DB_SERVER_PROTOCOL:-http://}
+      - DB_SERVER_HOST=database:5984
+      - DB_SERVER_USER=${DB_SERVER_USER:-admin}
+      - DB_SERVER_PASSWORD=${DB_SERVER_PASSWORD:-admin}
+      - CAUTH_USER_DB=${CAUTH_USER_DB:-auth-users}
+      - CAUTH_COUCH_AUTH_DB=${CAUTH_COUCH_AUTH_DB:-_users}
+    env_file: .env
+    ports:
+      - '3000:3000/tcp'
+      - '9095:9095/tcp'
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  database:
+    image: couchdb:3
+    volumes:
+      - database_dev_data:/opt/couchdb/data
+      - ./container/dev/couchdb.ini:/opt/couchdb/etc/local.d/10-custom.ini
+    environment:
+      - COUCHDB_USER=${DB_SERVER_USER:-admin}
+      - COUCHDB_PASSWORD=${DB_SERVER_PASSWORD:-admin}
+    env_file: .env
+    ports:
+      - '5984:5984/tcp'
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5984/_up"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  
+  database-init:
+    image: curlimages/curl:latest
+    depends_on:
+      database:
+        condition: service_healthy
+    environment:
+      - COUCHDB_USER=${DB_SERVER_USER:-admin}
+      - COUCHDB_PASSWORD=${DB_SERVER_PASSWORD:-admin}
+    env_file: .env
+    command:
+      - |
+        curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" -X PUT http://database:5984/_users
+        curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" -X PUT http://database:5984/_replicator
+        curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" -X PUT http://database:5984/_global_changes
+        curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" -X PUT http://database:5984/auth-users
+        curl -s -u "$$COUCHDB_USER:$$COUCHDB_PASSWORD" -X PUT http://database:5984/auth-users/_design/views \
+          -H 'Content-Type: application/json' \
+          -d '{"views":{"view-usernames":{"map":"function (doc) { if (doc.name) { emit(doc.name, null); } }"}}}'
+        echo 'Database CouchDB initialized.'
+    entrypoint: ["sh", "-c"]
+    restart: "no"
+
+volumes:
+  database_dev_data:

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -1,4 +1,4 @@
-name: Asterics-AAC for development environment
+name: asterics-aac-development
 
 services:
   application:

--- a/container/dev/couchdb.ini
+++ b/container/dev/couchdb.ini
@@ -1,0 +1,15 @@
+[couchdb]
+max_document_size = 4294967296
+os_process_timeout = 5000
+
+[chttpd]
+enable_cors = true
+port = 5984
+bind_address = 0.0.0.0
+max_http_request_size = 4294967296
+
+[cors]
+origins = *
+credentials = true
+methods = GET, PUT, POST, HEAD, DELETE, OPTIONS
+headers = accept, authorization, content-type, origin, referer, x-csrf-token, x-couchdb-vhost-21010

--- a/container/dev/entrypoint.sh
+++ b/container/dev/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+yarn install --frozen-lockfile
+yarn build
+npm run start-auth &
+
+exec npm start


### PR DESCRIPTION
This pull request adds support for running the application with Docker for the development.

- [Dockerfile.dev](https://github.com/asterics/Asterics-AAC/compare/master...Akipe:Asterics-AAC:feature%23828/add-docker-support?expand=1#diff-86930c95a19b82f7e64a962a0053d44e855824813019b3698eae4917a90cdcac) defines how to create the application container. 
- [compose.dev.yml](https://github.com/asterics/Asterics-AAC/compare/master...Akipe:Asterics-AAC:feature%23828/add-docker-support?expand=1#diff-bfb72f2c1c0b7deb52e32346fe2a5dadd2a489cedd430a2cc12e2ce57e7c2f51) defines how to run the application with CouchDB.
- [entrypoint.sh](https://github.com/asterics/Asterics-AAC/compare/master...Akipe:Asterics-AAC:feature%23828/add-docker-support?expand=1#diff-7640fb20133a544b907759e12301bfffa360c403dbe652fec969994136bc8dda) is invoked when executing the container.
- [couchdb.ini](https://github.com/asterics/Asterics-AAC/compare/master...Akipe:Asterics-AAC:feature%23828/add-docker-support?expand=1#diff-0b06ebaf486a0610fade66ddd6d56b9d1bffe4ee69f43c25bc2888544330f008) is the database configuration. *It may be incorrect*.
